### PR TITLE
feat: whiskers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@
 
 ## Usage
 
-1. Copy the contents of the desired flavour into `~/.config/fr33zmenu/menu.toml`
+> [!NOTE]
+> Catppuccin Mocha is already the default theme for fr33zmenu.
 
-> Note: Catppuccin Mocha is already the default theme for fr33zmenu
+1. Copy the contents of the flavor of your choice from [`themes/`](./themes/) into `~/.config/fr33zmenu/menu.toml`.
 
 ## 💝 Thanks to
 

--- a/fr33zmenu.tera
+++ b/fr33zmenu.tera
@@ -1,0 +1,23 @@
+---
+whiskers:
+  version: 2.1.0
+  matrix:
+    - flavor
+  filename: "themes/catppuccin-{{ flavor.identifier }}.toml"
+---
+
+{%- set palette = flavor.colors -%}
+
+# Catppuccin {{ flavor.name }}
+[theme]
+prompt             = { fg = "#{{ palette.green.hex }}", attrs = "bold" }
+input              = { fg = "#{{ palette.text.hex }}" }
+entry_name         = { fg = "#{{ palette.text.hex }}" }
+entry_value        = { fg = "#{{ palette.overlay1.hex }}" }
+entry_match        = { fg = "#{{ palette.sapphire.hex }}", attrs = "bold" }
+entry_hidden       = { fg = "#{{ palette.surface1.hex }}" }
+entry_cursor       = { fg = "#{{ palette.base.hex }}", bg = "#{{ palette.sapphire.hex }}", attrs = "bold" }
+entry_cursor_match = { fg = "#{{ palette.base.hex }}", bg = "#{{ palette.teal.hex }}", attrs = "bold" }
+menu_name          = { fg = "#{{ palette.red.hex }}" }
+menu_cursor        = { fg = "#{{ palette.base.hex }}", bg = "#{{ palette.red.hex }}", attrs = "bold" }
+overflow           = { fg = "#{{ palette.yellow.hex }}", attrs = "bold" }

--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers fr33zmenu.tera

--- a/themes/catppuccin-frappe.toml
+++ b/themes/catppuccin-frappe.toml
@@ -1,4 +1,4 @@
-# frappe
+# Catppuccin Frappé
 [theme]
 prompt             = { fg = "#a6d189", attrs = "bold" }
 input              = { fg = "#c6d0f5" }

--- a/themes/catppuccin-latte.toml
+++ b/themes/catppuccin-latte.toml
@@ -1,4 +1,4 @@
-# latte
+# Catppuccin Latte
 [theme]
 prompt             = { fg = "#40a02b", attrs = "bold" }
 input              = { fg = "#4c4f69" }

--- a/themes/catppuccin-macchiato.toml
+++ b/themes/catppuccin-macchiato.toml
@@ -1,4 +1,4 @@
-# macchiato
+# Catppuccin Macchiato
 [theme]
 prompt             = { fg = "#a6da95", attrs = "bold" }
 input              = { fg = "#cad3f5" }

--- a/themes/catppuccin-mocha.toml
+++ b/themes/catppuccin-mocha.toml
@@ -1,4 +1,4 @@
-# mocha
+# Catppuccin Mocha
 [theme]
 prompt             = { fg = "#a6e3a1", attrs = "bold" }
 input              = { fg = "#cdd6f4" }


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's internal templating tool, to build the themes. Instead of editing the `.toml` files directly, edit the `fr33zmenu.tera` file and then run `just build` to build the output themes. You will need Whiskers (linked above) and *optionally* [Just](https://github.com/casey/just) (for the `just build` shortcut) installed. I've also updated the usage instructions.